### PR TITLE
Add core2 build option

### DIFF
--- a/Dockerfile-focal
+++ b/Dockerfile-focal
@@ -1,9 +1,59 @@
-FROM ubuntu:focal AS build
+FROM ubuntu:focal AS mongo-src
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
+
+ARG CPU_ARCH=nehalem
+
+RUN echo "CPU Architecture: ${CPU_ARCH}"
+
+RUN apt-get clean && apt-get update && apt-get install -y  \
+    git \
+    tzdata \
+    software-properties-common \
+    manpages-dev \
+    build-essential \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    liblzma-dev
+
+
+RUN mkdir /src
+WORKDIR /src
+
+COPY . /src
+
+RUN git submodule update --init --remote --checkout mongo
+
+WORKDIR /src/mongo
+
+RUN git checkout r8.0.4
+
+# Create patches directory
+COPY patches /src/mongo/patches
+# Copy architecture-specific patches if applicable
+RUN if [ "$CPU_ARCH" = "core2" ]; then \
+        cp patches/${CPU_ARCH}/*.patch patches ; \
+    fi
+
+# Apply patches
+RUN for patch in $(ls patches/*.patch | sort); do patch -p0 < $patch; done
+
+
+FROM ubuntu:focal
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
 
 ARG NUM_CORES
+ARG CPU_ARCH=nehalem
+
+ENV CCFLAGS="-march=${CPU_ARCH}"
+
+# Copy only the mongo source
+COPY --from=mongo-src /src /src
+
+WORKDIR /src/mongo
 
 RUN apt-get clean && apt-get update
 
@@ -44,21 +94,7 @@ RUN update-alternatives --remove-all cpp
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9 --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-9 --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-9  --slave /usr/bin/cpp cpp /usr/bin/cpp-9
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11 --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-11 --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-11  --slave /usr/bin/cpp cpp /usr/bin/cpp-11
 
-RUN mkdir /src
-WORKDIR /src
-
-COPY . /src
-
-RUN git submodule update --init --remote --checkout mongo \
-    && cd mongo \
-    && git checkout r8.0.4
-
-WORKDIR /src/mongo
-
-# Apply patches
-COPY patches/*.patch /src/mongo
-RUN for patch in $(ls *.patch | sort); do patch -p0 < $patch; done
-
+#
 # Set up Python virtual environment and install requirements
 RUN python3.10 -m venv .venv --prompt mongo && . .venv/bin/activate
 RUN pip install 'poetry==1.5.1'
@@ -72,7 +108,7 @@ RUN . .venv/bin/activate && \
     --dbg=off \
     --disable-warnings-as-errors \
     --experimental-optimization=-sandybridge \
-     CCFLAGS="-march=nehalem"
+    CCFLAGS="${CCFLAGS}"
 
 RUN mkdir -p /tmp/output && \
     cd build/install/bin/ && \
@@ -80,4 +116,3 @@ RUN mkdir -p /tmp/output && \
 
 RUN cd /tmp/output && \
     zip -r mongod.zip mongod
-

--- a/Dockerfile-jammy
+++ b/Dockerfile-jammy
@@ -1,9 +1,59 @@
-FROM ubuntu:jammy AS build
+FROM ubuntu:jammy AS mongo-src
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
+
+ARG CPU_ARCH=nehalem
+
+RUN echo "CPU Architecture: ${CPU_ARCH}"
+
+RUN apt-get clean && apt-get update && apt-get install -y  \
+    git \
+    tzdata \
+    software-properties-common \
+    manpages-dev \
+    build-essential \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    liblzma-dev
+
+# Create and navigate to the src directory
+RUN mkdir /src
+WORKDIR /src
+
+COPY . /src
+
+RUN git submodule update --init --remote --checkout mongo
+
+WORKDIR /src/mongo
+
+RUN git checkout r8.0.4
+
+# Create patches directory
+COPY patches /src/mongo/patches
+# Copy architecture-specific patches if applicable
+RUN if [ "$CPU_ARCH" = "core2" ]; then \
+        cp patches/${CPU_ARCH}/*.patch patches ; \
+    fi
+
+# Apply patches
+RUN for patch in $(ls patches/*.patch | sort); do patch -p0 < $patch; done
+
+
+FROM ubuntu:jammy
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
 
 ARG NUM_CORES
+ARG CPU_ARCH=nehalem
+
+ENV CCFLAGS="-march=${CPU_ARCH}"
+
+# Copy only the mongo source
+COPY --from=mongo-src /src /src
+
+WORKDIR /src/mongo
 
 RUN apt-get clean && apt-get update
 
@@ -22,23 +72,9 @@ RUN apt-get install -y \
     git \
     wget \
     tar \
+    zip \
     lld
 
-# Create and navigate to the src directory
-RUN mkdir /src
-WORKDIR /src
-
-COPY . /src
-
-RUN git submodule update --init --remote --checkout mongo \
-    && cd mongo \
-    && git checkout r8.0.4
-
-WORKDIR /src/mongo
-
-# Apply patches
-COPY patches/*.patch /src/mongo
-RUN for patch in $(ls *.patch | sort); do patch -p0 < $patch; done
 
 # Set up Python virtual environment and install requirements
 RUN python3 -m venv .venv --prompt mongo && . .venv/bin/activate
@@ -53,7 +89,7 @@ RUN . .venv/bin/activate && \
     --dbg=off \
     --disable-warnings-as-errors \
     --experimental-optimization=-sandybridge \
-     CCFLAGS="-march=nehalem"
+     CCFLAGS="${CCFLAGS}"
 
 
 RUN mkdir -p /tmp/output && \

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This project builds a custom MongoDB 8.0.* server package for different Ubuntu d
 
 It applies patches from the `patches/` directory to build MongoDB **without AVX** compiler flags, enabling compatibility with older CPUs that do not support AVX or AVX2 instructions.
 
+Now supporting old CPUs like core2 which lacks of SSE4.2, AVX and AVX2 instructions.
+
 This project is based on the official MongoDB source code, which is licensed under the Server Side Public License (SSPL) v1.  
 The original source code is available here:  
 https://github.com/mongodb/mongo
@@ -26,6 +28,10 @@ The following patches are applied to the MongoDB source tree:
 - **0004-Disable-advanced-features-gcc.patch**
   Improve compatibility and portability by avoiding advanced CPU-specific features.
 
+### For core2 CPUs
+
+- **core2/0005-disable-crc32-snappy**
+    Disables CRC32 support in Snappy compression for better compatibility with older CPUs.
 
 ---
 
@@ -45,4 +51,15 @@ Each Dockerfile includes build dependencies and scripts to produce a custom `mon
 To build the Docker image and generate a custom `mongod` file, run:
 
 ```sh
-./builder.sh "<REVISION>" <DISTRIBUTION> <NUMBER_OF_CPU_CORES>
+./builder.sh "<REVISION>" <DISTRIBUTION> <NUMBER_OF_CPU_CORES> <CPU_ARCH>
+```
+
+Example:
+
+```sh
+./builder.sh "12" "focal" 4 "core2"
+
+or 
+
+./builder.sh "12" "jammy" 4 "nehalem"
+```

--- a/builder.sh
+++ b/builder.sh
@@ -3,10 +3,11 @@
 REV=${1:+-$1}
 PLATFORM="${2:-focal}"
 NUM_CORES="${3:-4}"
+CPU_ARCH="${4:-nehalem}"
 
 DOCKER_FILE="Dockerfile-${PLATFORM}"
-DOCKER_TAG="$PLATFORM-custom-mongodb"
-UPLOAD_DIR="${PLATFORM}-mongodb-upload"
+DOCKER_TAG="${PLATFORM}-${CPU_ARCH}-custom-mongodb"
+UPLOAD_DIR="${PLATFORM}-${CPU_ARCH}-mongodb-upload"
 
-docker build --file "${DOCKER_FILE}" -t "${DOCKER_TAG}" --build-arg REV="${REV}" --build-arg NUM_CORES="${NUM_CORES}" .
+docker build --file "${DOCKER_FILE}" -t "${DOCKER_TAG}" --build-arg REV="${REV}" --build-arg NUM_CORES="${NUM_CORES}" --build-arg CPU_ARCH="${CPU_ARCH}" .
 docker run --rm -v "${UPLOAD_DIR}":/tmp/output/ "${DOCKER_TAG}"

--- a/patches/core2/0005-disable-crc32-snappy.patch
+++ b/patches/core2/0005-disable-crc32-snappy.patch
@@ -1,0 +1,11 @@
+--- src/third_party/snappy/dist/snappy.cc
++++ src/third_party/snappy/dist/snappy.cc
+@@ -221,8 +221,6 @@ inline uint16_t* TableEntry(uint16_t* table, uint32_t bytes, uint32_t mask) {
+   // Mathematically, _mm_crc32_u32 (or similar) is a function of the
+   // xor of its arguments.
+   const uint32_t hash = __crc32cw(bytes, mask);
+-#elif SNAPPY_HAVE_X86_CRC32
+-  const uint32_t hash = _mm_crc32_u32(bytes, mask);
+ #else
+   constexpr uint32_t kMagic = 0x1e35a7bd;
+   const uint32_t hash = (kMagic * bytes) >> (31 - kMaxHashTableBits);


### PR DESCRIPTION
Merge of https://github.com/Axcient/mongod-avx/pull/3 into main branch.

- Adding `core2` build for older CPUs.
- Updating README