### PR TITLE
RB-16121: Rebuild mongodb-server package to the latest 8.0.x version

### DIFF
--- a/Dockerfile-jammy
+++ b/Dockerfile-jammy
@@ -31,6 +31,10 @@ RUN git checkout r8.0.17
 
 # Patches
 COPY patches /src/mongo/patches
+# Copy architecture-specific patches if applicable
+RUN if [ "$CPU_ARCH" = "core2" ]; then \
+		cp patches/${CPU_ARCH}/*.patch patches ; \
+	fi
 
 # Apply patches
 RUN for patch in $(ls patches/*.patch | sort); do patch -p0 < $patch; done

--- a/Dockerfile-noble
+++ b/Dockerfile-noble
@@ -31,6 +31,10 @@ RUN git checkout r8.0.17
 
 # Patches
 COPY patches /src/mongo/patches
+# Copy architecture-specific patches if applicable
+RUN if [ "$CPU_ARCH" = "core2" ]; then \
+		cp patches/${CPU_ARCH}/*.patch patches ; \
+	fi
 
 # Apply patches
 RUN for patch in $(ls patches/*.patch | sort); do patch -p0 < $patch; done

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project builds a custom MongoDB 8.0.* server package for **Ubuntu 22.04 (Ja
 
 It applies patches from the `patches/` directory to build MongoDB **without AVX** compiler flags, enabling compatibility with older CPUs that do not support AVX or AVX2 instructions.
 
-The build uses `--copt=-march=${CPU_ARCH}` (for example `nehalem`) so you can target older machines that lack AVX/AVX2.
+The build uses `--copt=-march=${CPU_ARCH}` (for example `nehalem` or `core2`) so you can target older machines. Core&nbsp;2–class CPUs lack SSE4.2 as well as AVX/AVX2; when `CPU_ARCH=core2`, an extra Snappy patch is applied (see below).
 
 This project is based on the official MongoDB source code, which is licensed under the Server Side Public License (SSPL) v1.  
 The original source code is available here:  
@@ -28,8 +28,10 @@ The following patches are applied to the MongoDB source tree:
 - **0004-Disable-advanced-features-gcc.patch**
   Improves compatibility and portability by avoiding advanced CPU-specific features.
 
-- **0007-Fix-pessimizing-move-in-expression_hasher-for-GCC13.patch**  
-  Removes a redundant `std::move` on a returned temporary so **GCC 13** (e.g. Ubuntu 24.04) does not fail with `-Werror=pessimizing-move`. Jammy’s GCC 11 is lenient here.
+### For core2 (`--build-arg CPU_ARCH=core2`)
+
+- **core2/0005-disable-crc32-snappy.patch**  
+  Disables the x86 CRC32 fast path in Snappy (uses a portable hash instead), avoiding SSE4.2 `crc32` instructions that Core&nbsp;2 does not support.
 
 ---
 
@@ -58,12 +60,14 @@ Example:
 
 ```sh
 ./builder.sh "12" "nehalem"
+./builder.sh "12" "core2"
 ```
 
-`CPU_ARCH` is any valid GCC `-march=` value (default in scripts/Dockerfile: `nehalem`).
+`CPU_ARCH` is any valid GCC `-march=` value (default in Dockerfile: `nehalem`). For Core&nbsp;2, use `core2` so the Dockerfile merges in the Snappy CRC32 patch.
 
 ### Examples (Noble)
 
 ```sh
 ./builder.sh "12" "nehalem" noble
+./builder.sh "12" "core2" noble
 ```

--- a/patches/core2/0005-disable-crc32-snappy.patch
+++ b/patches/core2/0005-disable-crc32-snappy.patch
@@ -1,0 +1,11 @@
+--- src/third_party/snappy/dist/snappy.cc
++++ src/third_party/snappy/dist/snappy.cc
+@@ -221,8 +221,6 @@ inline uint16_t* TableEntry(uint16_t* table, uint32_t bytes, uint32_t mask) {
+   // Mathematically, _mm_crc32_u32 (or similar) is a function of the
+   // xor of its arguments.
+   const uint32_t hash = __crc32cw(bytes, mask);
+-#elif SNAPPY_HAVE_X86_CRC32
+-  const uint32_t hash = _mm_crc32_u32(bytes, mask);
+ #else
+   constexpr uint32_t kMagic = 0x1e35a7bd;
+   const uint32_t hash = (kMagic * bytes) >> (31 - kMaxHashTableBits);


### PR DESCRIPTION
Issue
RB-16121

### Description

Adding `core2` back to build types; it's still necessary for specific core2 old machines.

### What's changed
- core2 CPU type was reverted

### Tests

Tested core2 build:
- copied mongod binary
- started standalone mongo and tested it

```
mkdir -p /tmp/mtest
./mongod --dbpath="/tmp/mtest" --port 27029
```

and

```
mongo --port 27029
```